### PR TITLE
Add Image upload with preview example

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,4 @@
 
 * [Feedback form](feedback-form)
 * [Markdown preview](markdown-preview)
+* [Image upload with preview](image-upload-with-preview)

--- a/image-upload-with-preview/README.md
+++ b/image-upload-with-preview/README.md
@@ -55,10 +55,10 @@ AMAZON_BUCKET_NAME=
 (($) ->
 
   class PreviewImage
-    constructor: (input) ->
-      @dataKey = "preview"
+    constructor: (element) ->
+      @dataKey = "file-preview"
       @defaults = width: 200
-      @options = @_options(input)
+      @options = @_options(element)
 
       @_bind()
 
@@ -85,7 +85,7 @@ AMAZON_BUCKET_NAME=
     _options: (input) ->
       $.extend @defaults, $(input).data(@dataKey)
 
-  $.fn.filePreview = (e) ->
+  $.fn.filePreview = ->
     return unless @length
     new PreviewImage(this)
 
@@ -134,7 +134,7 @@ AMAZON_BUCKET_NAME=
 
 $(document).on "ready page:load", ->
   $("[data-file-remove]").fileRemove()
-  $("[data-preview]").filePreview()
+  $("[data-file-preview]").filePreview()
 ```
 
 ```ruby
@@ -160,22 +160,22 @@ end
 ```slim
 / app/views/users/registrations/edit.html.slim
 
-        .edit-profile-photo
-          .wrap
-            = attachment_image_tag(resource, :avatar, :fill, 200, 200, format: "jpg",
-                fallback: "defaultavatar.png", id: "avatar-image")
-          .actions
-            .change
-              = f.input :avatar, as: :attachment, direct: true, presigned: true
-                  input_html: { data: { preview: { selector: "avatar-image",
-                    remove_selector: "[data-file-remove]" } } }
+.edit-profile-photo
+  .wrap
+    = attachment_image_tag(resource, :avatar, :fill, 200, 200, format: "jpg",
+        fallback: "defaultavatar.png", id: "avatar-image")
+  .actions
+    .change
+      = f.input :avatar, as: :attachment, direct: true, presigned: true
+          input_html: { data: { "file-preview" => { selector: "avatar-image",
+            remove_selector: "[data-file-remove]" } } }
 
-            .remove
-              = link_to "Remove avatar", "#",
-                  data: { "file-remove" => { selector: "avatar-image", hidden: "user_remove_avatar",
-                    file_input: "user_avatar", default: image_path("defaultavatar.png") } },
-                  class: "button small alert #{resource.avatar.nil? ? 'hidden' : ''}"
-              = f.check_box :remove_avatar, class: "hidden"
+    .remove
+      = link_to "Remove avatar", "#",
+          data: { "file-remove" => { selector: "avatar-image", hidden: "user_remove_avatar",
+            file_input: "user_avatar", default: image_path("defaultavatar.png") } },
+          class: "button small alert #{resource.avatar.nil? ? 'hidden' : ''}"
+      = f.check_box :remove_avatar, class: "hidden"
 ```
 
 Unfortunately `Refile::FileDouble` does not work with capybara.

--- a/image-upload-with-preview/README.md
+++ b/image-upload-with-preview/README.md
@@ -42,6 +42,15 @@ AMAZON_BUCKET_REGION=
 AMAZON_BUCKET_NAME=
 ```
 
+```ruby
+# .env.example
+
+AMAZON_ACCESS_KEY_ID=
+AMAZON_SECRET_ACCESS_KEY=
+AMAZON_BUCKET_REGION=
+AMAZON_BUCKET_NAME=
+```
+
 ```coffee
 # app/assets/javascripts/application.coffee
 
@@ -54,7 +63,7 @@ AMAZON_BUCKET_NAME=
 
 (($) ->
 
-  class PreviewImage
+  class FilePreview
     constructor: (element) ->
       @dataKey = "file-preview"
       @defaults = width: 200
@@ -87,7 +96,7 @@ AMAZON_BUCKET_NAME=
 
   $.fn.filePreview = ->
     return unless @length
-    new PreviewImage(this)
+    new FilePreview(this)
 
 ) jQuery
 ```
@@ -97,7 +106,7 @@ AMAZON_BUCKET_NAME=
 
 (($) ->
 
-  class RemoveImage
+  class FileRemove
     constructor: (element) ->
       @dataKey = "file-remove"
       @options = element.data(@dataKey)
@@ -124,7 +133,7 @@ AMAZON_BUCKET_NAME=
 
   $.fn.fileRemove = ->
     return unless @length
-    new RemoveImage(this)
+    new FileRemove(this)
 
 ) jQuery
 ```
@@ -247,7 +256,7 @@ feature "Remove Avatar", js: true do
 end
 ```
 
-Allow to connect to codeclimate from tests so that build would not brake up on semaphore.
+Allow to connect to CodeClimate from tests so that build would not break up on SemaphoreCI.
 
 ```ruby
 # spec/rails_helper.rb

--- a/image-upload-with-preview/README.md
+++ b/image-upload-with-preview/README.md
@@ -1,0 +1,261 @@
+# Upload user profile image to s3 with refile
+
+Reference:
+* [Refile](https://github.com/refile/refile)
+---
+
+```bash
+rails g migration AddAvatarIdToUsers avatar_id:string
+```
+
+```ruby
+# Gemfile
+
+gem "refile", require: "refile/rails"
+gem "refile-mini_magick"
+gem "refile-s3"
+```
+
+```ruby
+# config/initializers/refile.rb
+
+require "refile/s3"
+require "refile/simple_form"
+
+aws = {
+  access_key_id: ENV["AMAZON_ACCESS_KEY_ID"],
+  secret_access_key: ENV["AMAZON_SECRET_ACCESS_KEY"],
+  region: ENV["AMAZON_BUCKET_REGION"],
+  bucket: ENV["AMAZON_BUCKET_NAME"]
+}
+Refile.cache = Refile::S3.new(prefix: "cache", **aws)
+Refile.store = Refile::S3.new(prefix: "store", **aws)
+```
+
+```ruby
+# .env
+
+AMAZON_ACCESS_KEY_ID=
+AMAZON_SECRET_ACCESS_KEY=
+AMAZON_BUCKET_REGION=
+AMAZON_BUCKET_NAME=
+```
+
+```coffee
+# app/assets/javascripts/application.coffee
+
+#= require refile
+#= require_tree ./files
+```
+
+```coffee
+# app/assets/javascripts/files/file-preview.coffee
+
+(($) ->
+
+  class PreviewImage
+    constructor: (input) ->
+      @dataKey = "preview"
+      @defaults = width: 200
+      @options = @_options(input)
+
+      @_bind()
+
+    _bind: ->
+      $("body").on "change", "[data-" + @dataKey + "]", (e) =>
+        @_show(e.target)
+
+    _show: (input) ->
+      if input.files and input.files[0]
+        reader = new FileReader
+
+        reader.onload = (e) =>
+          @_image(input)
+            .attr("src", e.target.result)
+            .attr("width", @options.width)
+
+          $(@options.remove_selector).trigger("remove-#{@options.selector}:reset")
+
+        reader.readAsDataURL input.files[0]
+
+    _image: (input) =>
+      $("#" + @options.selector)
+
+    _options: (input) ->
+      $.extend @defaults, $(input).data(@dataKey)
+
+  $.fn.filePreview = (e) ->
+    return unless @length
+    new PreviewImage(this)
+
+) jQuery
+```
+
+```coffee
+# app/assets/javascripts/files/file-remove.coffee
+
+(($) ->
+
+  class RemoveImage
+    constructor: (element) ->
+      @dataKey = "file-remove"
+      @options = element.data(@dataKey)
+      @element = element
+      @_bind()
+
+    _bind: ->
+      $("body").on "click", "[data-" + @dataKey + "]", (e) =>
+        e.preventDefault()
+        @_remove()
+
+      $("body").on "remove-#{@options.selector}:reset", "[data-" + @dataKey + "]", (e) =>
+        @element.removeClass("hidden")
+        @_reset()
+
+    _remove: =>
+      $("#" + @options.selector).attr("src", @options.default)
+      $("#" + @options.hidden).prop("checked", true)
+      $("#" + @options.file_input).val("")
+      @element.addClass("hidden")
+
+    _reset: =>
+      $("#" + @options.hidden).val(false)
+
+  $.fn.fileRemove = ->
+    return unless @length
+    new RemoveImage(this)
+
+) jQuery
+```
+
+```coffee
+# app/assets/javascripts/users/edit-profile.coffee
+
+$(document).on "ready page:load", ->
+  $("[data-file-remove]").fileRemove()
+  $("[data-preview]").filePreview()
+```
+
+```ruby
+# app/models/user.rb
+
+class User < ActiveRecord::Base
+  # ...
+
+  attachment :avatar
+
+  # ...
+end
+```
+
+```ruby
+# app/sanitizers/user/parameter_sanitizer.rb
+
+  def account_update
+    default_params.permit(USER_PARAMS, :current_password, :avatar, :remove_avatar)
+  end
+```
+
+```slim
+/ app/views/users/registrations/edit.html.slim
+
+        .edit-profile-photo
+          .wrap
+            = attachment_image_tag(resource, :avatar, :fill, 200, 200, format: "jpg",
+                fallback: "defaultavatar.png", id: "avatar-image")
+          .actions
+            .change
+              = f.input :avatar, as: :attachment, direct: true, presigned: true
+                  input_html: { data: { preview: { selector: "avatar-image",
+                    remove_selector: "[data-file-remove]" } } }
+
+            .remove
+              = link_to "Remove avatar", "#",
+                  data: { "file-remove" => { selector: "avatar-image", hidden: "user_remove_avatar",
+                    file_input: "user_avatar", default: image_path("defaultavatar.png") } },
+                  class: "button small alert #{resource.avatar.nil? ? 'hidden' : ''}"
+              = f.check_box :remove_avatar, class: "hidden"
+```
+
+Unfortunately `Refile::FileDouble` does not work with capybara.
+Before running tests save any lightweight image as `spec/fixtures/avatar.png`.
+For instance [this one](http://i7.5cm.ru/i/TWFB.png).
+
+```ruby
+# spec/features/user/account/avatar_spec.rb
+
+require "rails_helper"
+
+feature "Upload Avatar" do
+  let(:file) { File.open(Rails.root.join("spec/fixtures/avatar.png")) }
+
+  include_context "current user signed in"
+
+  def visit_profile_settings
+    visit edit_user_registration_path(current_user)
+  end
+
+  def upload_avatar
+    visit_profile_settings
+    fill_form(:user, current_password: current_user.password, avatar: file)
+    click_on "Update"
+  end
+
+  background do
+    stub_request(:any, /amazonaws.com/)
+  end
+
+  scenario "User uploads avatar" do
+    upload_avatar
+    visit_profile_settings
+
+    expect(page).to have_css("img[alt='Avatar']")
+  end
+
+  describe "Removal" do
+    background do
+      upload_avatar
+      visit_profile_settings
+    end
+
+    scenario "User removes avatar", js: true do
+      click_on "Remove avatar"
+      fill_form(:user, current_password: current_user.password)
+      click_on "Update"
+
+      visit_profile_settings
+
+      expect(page).to have_css("img[alt='Defaultavatar']")
+    end
+  end
+end
+```
+
+Allow to connect to codeclimate from tests so that build would not brake up on semaphore.
+
+```ruby
+# spec/rails_helper.rb
+
+require "webmock/rspec"
+
+WebMock.disable_net_connect!(allow_localhost: true, allow: %w(codeclimate.com))
+```
+
+On Amazon S3 go to bucket "Properties" -> "Permissions" -> "Edit CORS Configuration"
+
+Set:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+    <CORSRule>
+        <AllowedOrigin>{IP ADDRESS or *}</AllowedOrigin>
+        <AllowedMethod>GET</AllowedMethod>
+        <AllowedMethod>POST</AllowedMethod>
+        <MaxAgeSeconds>3000</MaxAgeSeconds>
+        <AllowedHeader>Authorization</AllowedHeader>
+        <AllowedHeader>Content-Type</AllowedHeader>
+        <AllowedHeader>Origin</AllowedHeader>
+    </CORSRule>
+</CORSConfiguration>
+```


### PR DESCRIPTION
- Direct upload to S3 bucket.
- CoffeeScript classes for file preview and removal are extracted to jquery functions.
- [Enabling CORS](http://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html) on amazon is required (configuration example is also available in readme).
