### PR TITLE
Translations for Action Mailer E-Mail Subjects

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 * [Feedback form](feedback-form)
 * [Markdown preview](markdown-preview)
 * [Image upload with preview](image-upload-with-preview)
-* [Translations for Action Mailer](translations-for-action-mailer)
+* [Translation for Action Mailer trought locales](translations-for-action-mailer)

--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 * [Feedback form](feedback-form)
 * [Markdown preview](markdown-preview)
 * [Image upload with preview](image-upload-with-preview)
-* [Translations for Action Mailer E-Mail Subjects trought locales](translations-for-action-mailer-subjects)
+* [Translations for Action Mailer E-Mail Subjects](translations-for-action-mailer-subjects)

--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 * [Feedback form](feedback-form)
 * [Markdown preview](markdown-preview)
 * [Image upload with preview](image-upload-with-preview)
-* [Translation for Action Mailer trought locales](translations-for-action-mailer)
+* [Translations for Action Mailer E-Mail Subjects trought locales](translations-for-action-mailer-subjects)

--- a/README.md
+++ b/README.md
@@ -3,3 +3,4 @@
 * [Feedback form](feedback-form)
 * [Markdown preview](markdown-preview)
 * [Image upload with preview](image-upload-with-preview)
+* [Translations for Action Mailer](translations-for-action-mailer)

--- a/translations-for-action-mailer-subjects/README.md
+++ b/translations-for-action-mailer-subjects/README.md
@@ -28,7 +28,7 @@ en:
 ```
 
 ```slim
-# views/application_mailer/send_weekly_report_notifier.html.slim
+/ views/application_mailer/send_weekly_report_notifier.html.slim
 
 h1 Hi, #{@manager.full_name}! There is some job for you!
 

--- a/translations-for-action-mailer-subjects/README.md
+++ b/translations-for-action-mailer-subjects/README.md
@@ -1,4 +1,4 @@
-# Translation for Action Mailer trought locales
+# Translations for Action Mailer E-Mail Subjects trought locales
 If you don't pass a subject to the mail method, Action Mailer will try to find it in your translations.
 The performed lookup will use the pattern ``<mailer_scope>.<action_name>.subject`` to construct the key.
 

--- a/translations-for-action-mailer-subjects/README.md
+++ b/translations-for-action-mailer-subjects/README.md
@@ -1,4 +1,4 @@
-# Translations for Action Mailer E-Mail Subjects trought locales
+# Translations for Action Mailer E-Mail Subjects
 If you don't pass a subject to the mail method, Action Mailer will try to find it in your translations.
 The performed lookup will use the pattern ``<mailer_scope>.<action_name>.subject`` to construct the key.
 

--- a/translations-for-action-mailer/README.md
+++ b/translations-for-action-mailer/README.md
@@ -27,7 +27,7 @@ en:
 
 ```
 
-```ruby
+```slim
 # views/application_mailer/send_weekly_report_notifier.html.slim
 
 h1 Hi, #{@manager.full_name}! There is some job for you!

--- a/translations-for-action-mailer/README.md
+++ b/translations-for-action-mailer/README.md
@@ -3,7 +3,7 @@ If you don't pass a subject to the mail method, Action Mailer will try to find i
 The performed lookup will use the pattern ``<mailer_scope>.<action_name>.subject`` to construct the key.
 
 
-```
+```ruby
 #mailers/application_mailer.rb
 
 class ApplicationMailer < ActionMailer::Base
@@ -17,7 +17,7 @@ end
 
 ```
 
-```
+```ruby
 # config/locales/mailers.en.yml
 
 en:
@@ -27,7 +27,7 @@ en:
 
 ```
 
-```
+```ruby
 #views/application_mailer/send_weekly_report_notifier.html.slim
 
 h1 Hi, #{@manager.full_name}! There is some job for you!
@@ -44,7 +44,7 @@ ul
 
 If you want to send parameters to interpolation use the default_i18n_subject method on the mailer.
 
-```
+```ruby
 #mailers/application_mailer.rb
 
 class ApplicationMailer < ActionMailer::Base
@@ -58,7 +58,7 @@ end
 
 ```
 
-```
+```ruby
 # config/locales/mailers.en.yml
 
 en:

--- a/translations-for-action-mailer/README.md
+++ b/translations-for-action-mailer/README.md
@@ -4,7 +4,7 @@ The performed lookup will use the pattern ``<mailer_scope>.<action_name>.subject
 
 
 ```ruby
-#mailers/application_mailer.rb
+# mailers/application_mailer.rb
 
 class ApplicationMailer < ActionMailer::Base
   def send_weekly_report_notifier(manager, projects)
@@ -17,7 +17,7 @@ end
 
 ```
 
-```ruby
+```yml
 # config/locales/mailers.en.yml
 
 en:
@@ -28,7 +28,7 @@ en:
 ```
 
 ```ruby
-#views/application_mailer/send_weekly_report_notifier.html.slim
+# views/application_mailer/send_weekly_report_notifier.html.slim
 
 h1 Hi, #{@manager.full_name}! There is some job for you!
 
@@ -45,7 +45,7 @@ ul
 If you want to send parameters to interpolation use the default_i18n_subject method on the mailer.
 
 ```ruby
-#mailers/application_mailer.rb
+# mailers/application_mailer.rb
 
 class ApplicationMailer < ActionMailer::Base
   def send_weekly_report_notifier(manager, projects)
@@ -58,7 +58,7 @@ end
 
 ```
 
-```ruby
+```yml
 # config/locales/mailers.en.yml
 
 en:

--- a/translations-for-action-mailer/README.md
+++ b/translations-for-action-mailer/README.md
@@ -1,0 +1,69 @@
+# Translation for Action Mailer trought locales
+If you don't pass a subject to the mail method, Action Mailer will try to find it in your translations.
+The performed lookup will use the pattern ``<mailer_scope>.<action_name>.subject`` to construct the key.
+
+
+```
+#mailers/application_mailer.rb
+
+class ApplicationMailer < ActionMailer::Base
+  def send_weekly_report_notifier(manager, projects)
+    @manager = manager
+    @projects = projects
+
+    mail(to: manager.email)
+  end
+end
+
+```
+
+```
+# config/locales/mailers.en.yml
+
+en:
+  application_mailer:
+    send_weekly_report_notifier:
+      subject: He-hey, it is time to report!
+
+```
+
+```
+#views/application_mailer/send_weekly_report_notifier.html.slim
+
+h1 Hi, #{@manager.full_name}! There is some job for you!
+
+p Please, fill the weekly reports for your projects!
+
+p Project list:
+ul
+  - @projects.each do |project|
+    li = link_to(project)
+
+```
+
+
+If you want to send parameters to interpolation use the default_i18n_subject method on the mailer.
+
+```
+#mailers/application_mailer.rb
+
+class ApplicationMailer < ActionMailer::Base
+  def send_weekly_report_notifier(manager, projects)
+    @manager = manager
+    @projects = projects
+
+    mail(to: manager.email, subject: default_i18n_subject(manager: manager.full_name))
+  end
+end
+
+```
+
+```
+# config/locales/mailers.en.yml
+
+en:
+  application_mailer:
+    send_weekly_report_notifier:
+      subject: He-hey %{manager}, it is time to report!
+
+```


### PR DESCRIPTION
Example how to use Action Mailer Internationalization to define subjects in locales.
Based on: [Rails Internationalization (I18n) API](http://guides.rubyonrails.org/i18n.html#translations-for-action-mailer-e-mail-subjects)
